### PR TITLE
Fixing nav links

### DIFF
--- a/src/components/common/navigation/navigation.js
+++ b/src/components/common/navigation/navigation.js
@@ -54,11 +54,19 @@ export default class Navigation extends Component {
 
   getNavAnchorLink = item => {
     if (item.sectionId) {
-      return (
-        <AnchorLink href={`#${item.sectionId}`} onClick={this.closeMobileMenu}>
-          {item.title}
-        </AnchorLink>
-      )
+      if (window.location.href == item.pageURL) {
+        return (
+          <AnchorLink href={`#${item.sectionId}`} onClick={this.closeMobileMenu}>
+            {item.title}
+          </AnchorLink>
+        )
+      } else {
+        return (
+          <Link to={`${item.pageURL}#${item.sectionId}`} onClick={this.closeMobileMenu}>
+            {item.title}
+          </Link>
+        )
+      }
     } else {
       return (
         <Link to={`${item.pageURL}`} onClick={this.closeMobileMenu}>


### PR DESCRIPTION
Adding check so that the url is appended to the anchor link when not in the same page as the destination url.
Fixes the "About" and "Get Involved links" not working when user is in FAGs